### PR TITLE
start and end values to use calculate function

### DIFF
--- a/src/ng-slider.js
+++ b/src/ng-slider.js
@@ -42,6 +42,12 @@
 
 						scope.from = ''+scope.options.from;
 						scope.to = ''+scope.options.to;
+						
+						if(scope.options.calculate && typeof scope.options.calculate === 'function') {
+							scope.from = scope.options.calculate(scope.from);
+							scope.to = scope.options.calculate(scope.to);
+						}
+						
 						var OPTIONS = {						
 							from: scope.options.from,
 							to: scope.options.to,


### PR DESCRIPTION
If you use a calculate function on your values it is now applied on your start and end values as well (which are otherwise shown as given)

example: We use the slider for time of day. The start and end values would be shown as 0 and 1440 (for minutes) while the slider itself used minutes
